### PR TITLE
fix: podspec tag version

### DIFF
--- a/FormbricksSDK.podspec
+++ b/FormbricksSDK.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => "MIT", :file => "LICENSE" }
   s.author           = { "Formbricks" => "hola@formbricks.com" }
   s.platform         = :ios, "16.6"
-  s.source           = { :git => "https://github.com/formbricks/ios.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/formbricks/ios.git", :tag => "v#{s.version}" }
   s.swift_version    = "5.7"                                 # or whatever you require
   s.requires_arc     = true
   s.source_files     = "Sources/FormbricksSDK/**/*.{swift}"


### PR DESCRIPTION
This pull request makes a minor update to the `FormbricksSDK.podspec` file to adjust the `s.source` configuration for tagging. The change ensures consistency in how version tags are formatted in the source URL.

* [`FormbricksSDK.podspec`](diffhunk://#diff-843297c9a15a6c4477d3ea4e7fec89a55c878a5374dc999d1ed99d4461fab04cL9-R9): Updated the `s.source` tag format to use `"v#{s.version}"` instead of `s.version.to_s`, aligning with the versioning convention.