### PR TITLE
feat: ios sdk v1.0.1

### DIFF
--- a/FormbricksSDK.podspec
+++ b/FormbricksSDK.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name             = "FormbricksSDK"
-  s.version          = "1.0.0"                              
+  s.version          = "1.0.1"                              
   s.summary          = "iOS SDK for Formbricks" 
   s.homepage         = "https://github.com/formbricks/ios"   
   s.license          = { :type => "MIT", :file => "LICENSE" }
   s.author           = { "Formbricks" => "hola@formbricks.com" }
   s.platform         = :ios, "16.6"
   s.source           = { :git => "https://github.com/formbricks/ios.git", :tag => "v#{s.version}" }
-  s.swift_version    = "5.7"                                 # or whatever you require
+  s.swift_version    = "5.7"                                
   s.requires_arc     = true
   s.source_files     = "Sources/FormbricksSDK/**/*.{swift}"
 end

--- a/README.md
+++ b/README.md
@@ -8,8 +8,27 @@ The iOS SDK for Formbricks
 
 1. In Xcode choose **File → Add Packages…**
 2. Enter your repo URL (e.g. `https://github.com/formbricks/ios.git`)
-3. Choose version rule (e.g. “Up to Next Major” starting at `1.0.0`).
+3. Choose version rule (e.g. "Up to Next Major" starting at `1.0.0`).
 4. Import in your code:
+   ```swift
+   import FormbricksSDK
+   ```
+
+### CocoaPods
+
+1. Add the following to your `Podfile`:
+
+   ```ruby
+   platform :ios, '16.6'
+   use_frameworks! :linkage => :static
+
+   target 'YourTargetName' do
+     pod 'FormbricksSDK', '1.0.0 (or the latest version)'
+   end
+   ```
+
+2. Run `pod install` in your project directory
+3. Import in your code:
    ```swift
    import FormbricksSDK
    ```
@@ -53,4 +72,8 @@ Formbricks.logout()
 Formbricks.cleanup(waitForOperations: true) {
     print("SDK torn down")
 }
+```
+
+```
+
 ```

--- a/Sources/FormbricksSDK/Formbricks.swift
+++ b/Sources/FormbricksSDK/Formbricks.swift
@@ -91,6 +91,11 @@ import Network
             return
         }
         
+        if let existing = userManager?.userId, !existing.isEmpty {
+            logger?.error("A userId is already set (\"\(existing)\") – please call Formbricks.logout() before setting a new one.")
+            return
+        }
+        
         userManager?.set(userId: userId)
     }
     

--- a/Sources/FormbricksSDK/Manager/UserManager.swift
+++ b/Sources/FormbricksSDK/Manager/UserManager.swift
@@ -95,6 +95,9 @@ final class UserManager: UserManagerSyncable {
                 self?.lastDisplayedAt = userResponse.data.state?.data?.lastDisplayAt
                 self?.expiresAt = userResponse.data.state?.expiresAt
                 
+                let serverLanguage = userResponse.data.state?.data?.language
+                Formbricks.language = serverLanguage ?? "default"
+                
                 self?.updateQueue?.reset()
                 self?.surveyManager?.filterSurveys()
                 self?.startSyncTimer()
@@ -128,11 +131,13 @@ final class UserManager: UserManagerSyncable {
         backingResponses = nil
         backingLastDisplayedAt = nil
         backingExpiresAt = nil
+        Formbricks.language = "default"
         updateQueue?.reset()
         
         if isUserIdDefined {
             Formbricks.logger?.debug("Successfully logged out user and reset the user state.")
         }
+        
     }
     
     func cleanupUpdateQueue() {

--- a/Sources/FormbricksSDK/Model/User/UserStateDetails.swift
+++ b/Sources/FormbricksSDK/Model/User/UserStateDetails.swift
@@ -7,4 +7,5 @@ struct UserStateDetails: Codable {
     let displays: [Display]?
     let responses: [String]?
     let lastDisplayAt: Date?
+    let language: String?
 }

--- a/Sources/FormbricksSDK/Networking/Base/APIClient.swift
+++ b/Sources/FormbricksSDK/Networking/Base/APIClient.swift
@@ -12,131 +12,124 @@ class APIClient<Request: CodableRequest>: Operation, @unchecked Sendable {
     }
     
     override func main() {
-        guard let apiURL = request.baseURL, var baseUrlComponents = URLComponents(string: apiURL) else {
+        guard let finalURL = buildFinalURL() else {
             completion?(.failure(FormbricksSDKError(type: .sdkIsNotInitialized)))
             return
         }
-        
-        baseUrlComponents.queryItems = request.queryParams?.map { URLQueryItem(name: $0.key, value: $0.value) }
-        
-        guard var finalURL = baseUrlComponents.url else {
-            completion?(.failure(FormbricksSDKError(type: .invalidAppUrl)))
-            return
-        }
-        
-        guard let requestEndPoint = setPathParams(request.requestEndPoint) else {
-            completion?(.failure(FormbricksSDKError(type: .sdkIsNotInitialized)))
-            return
-        }
-        
-        finalURL.appendPathComponent(requestEndPoint)
         
         let urlRequest = createURLRequest(forURL: finalURL)
+        logRequest(urlRequest)
         
-        // LOG
-        var requestLogMessage = "\(request.requestType.rawValue) >>> "
-        if let urlString = urlRequest.url?.absoluteString {
-            requestLogMessage.append(urlString)
-        }
-        if let headers = urlRequest.allHTTPHeaderFields {
-            requestLogMessage.append("\nHeaders: \(headers)")
-        }
-        if let body = urlRequest.httpBody {
-            requestLogMessage.append("\nBody: \(String(data: body, encoding: .utf8) ?? "")")
-        }
-        
-        Formbricks.logger?.info(requestLogMessage)
-        
-        session.dataTask(with: urlRequest) { (data, response, error) in
-            if let httpStatus = (response as? HTTPURLResponse)?.status {
-                var responseLogMessage = "\(httpStatus.rawValue) <<< "
-                if let urlString = response?.url?.absoluteString {
-                    responseLogMessage.append(urlString)
-                }
-                
-                if httpStatus.responseType == .success {
-                    guard let data = data else {
-                        self.completion?(.failure(FormbricksAPIClientError(type: .invalidResponse, statusCode: httpStatus.rawValue)))
-                        return
-                    }
-                    if let responseString = String(data: data, encoding: .utf8) {
-                        responseLogMessage.append("\n\(responseString)\n")
-                    }
-                    
-                    do {
-                        if Request.Response.self == VoidResponse.self {
-                            Formbricks.logger?.info(responseLogMessage)
-                            
-                            if let response = VoidResponse() as? Request.Response {
-                                self.completion?(.success(response))
-                            } else {
-                                self.completion?(.failure(FormbricksAPIClientError(type: .invalidResponse)))
-                            }
-                        } else {
-                            var body = try self.request.decoder.decode(Request.Response.self, from: data)
-                            Formbricks.logger?.info(responseLogMessage)
-                            
-                            // We want to save the entire response dictionary for the environment response
-                            if var environmentResponse = body as? EnvironmentResponse,
-                               let jsonString = String(data: data, encoding: .utf8) {
-                                environmentResponse.responseString = jsonString
-                                body = environmentResponse as! Request.Response
-                            }
-
-                            
-                            self.completion?(.success(body))
-                        }
-                    }
-                    catch let DecodingError.dataCorrupted(context) {
-                        responseLogMessage.append("Data corrupted \(context)\n")
-                        Formbricks.logger?.error(responseLogMessage)
-                        self.completion?(.failure(FormbricksAPIClientError(type: .invalidResponse, statusCode: httpStatus.rawValue)))
-                    }
-                    catch let DecodingError.keyNotFound(key, context) {
-                        responseLogMessage.append("Key '\(key)' not found: \(context.debugDescription)\n")
-                        responseLogMessage.append("codingPath: \(context.codingPath)")
-                        Formbricks.logger?.error(responseLogMessage)
-                        self.completion?(.failure(FormbricksAPIClientError(type: .invalidResponse, statusCode: httpStatus.rawValue)))
-                    }
-                    catch let DecodingError.valueNotFound(value, context) {
-                        responseLogMessage.append("Value '\(value)' not found: \(context.debugDescription)\n")
-                        responseLogMessage.append("codingPath: \(context.codingPath)")
-                        Formbricks.logger?.error(responseLogMessage)
-                        self.completion?(.failure(FormbricksAPIClientError(type: .invalidResponse, statusCode: httpStatus.rawValue)))
-                    }
-                    catch let DecodingError.typeMismatch(type, context)  {
-                        responseLogMessage.append("Type '\(type)' mismatch: \(context.debugDescription)\n")
-                        responseLogMessage.append("codingPath: \(context.codingPath)")
-                        Formbricks.logger?.error(responseLogMessage)
-                        self.completion?(.failure(FormbricksAPIClientError(type: .invalidResponse, statusCode: httpStatus.rawValue)))
-                    }
-                    catch {
-                        responseLogMessage.append("error: \(error.message)")
-                        Formbricks.logger?.error(responseLogMessage)
-                        self.completion?(.failure(FormbricksAPIClientError(type: .invalidResponse, statusCode: httpStatus.rawValue)))
-                    }
-                } else {
-                    if let error = error {
-                        responseLogMessage.append("\nError: \(error.localizedDescription)")
-                        Formbricks.logger?.error(responseLogMessage)
-                        self.completion?(.failure(error))
-                    } else if let data = data, let apiError = try? self.request.decoder.decode(FormbricksAPIError.self, from: data) {
-                        Formbricks.logger?.error("\(responseLogMessage)\n\(apiError.getDetailedErrorMessage())")
-                        self.completion?(.failure(apiError))
-                    } else {
-                        let error = FormbricksAPIClientError(type: .responseError, statusCode: httpStatus.rawValue)
-                        Formbricks.logger?.error("\(responseLogMessage)\n\(error.message)")
-                        self.completion?(.failure(error))
-                    }
-                }
-            }
-            else {
-                let error = FormbricksAPIClientError(type: .invalidResponse)
-                Formbricks.logger?.error("ERROR \(error.message)")
-                self.completion?(.failure(error))
-            }
+        session.dataTask(with: urlRequest) { data, response, error in
+            self.processResponse(data: data, response: response, error: error)
         }.resume()
     }
+    
+    private func buildFinalURL() -> URL? {
+        guard let apiURL = request.baseURL, var components = URLComponents(string: apiURL) else { return nil }
+        
+        components.queryItems = request.queryParams?.map { URLQueryItem(name: $0.key, value: $0.value) }
+        
+        guard var url = components.url, let path = setPathParams(request.requestEndPoint) else { return nil }
+
+        url.appendPathComponent(path)
+        return url
+    }
+    
+    private func processResponse(data: Data?, response: URLResponse?, error: Error?) {
+        guard let httpStatus = (response as? HTTPURLResponse)?.status else {
+            let error = FormbricksAPIClientError(type: .invalidResponse)
+            Formbricks.logger?.error("ERROR \(error.message)")
+            completion?(.failure(error))
+            return
+        }
+
+        var message = "\(httpStatus.rawValue) <<< \(response?.url?.absoluteString ?? "")"
+        
+        if httpStatus.responseType == .success {
+            handleSuccessResponse(data: data, statusCode: httpStatus.rawValue, message: &message)
+        } else {
+            handleFailureResponse(data: data, error: error, statusCode: httpStatus.rawValue, message: message)
+        }
+    }
+    
+    private func handleSuccessResponse(data: Data?, statusCode: Int, message: inout String) {
+        guard let data = data else {
+            completion?(.failure(FormbricksAPIClientError(type: .invalidResponse, statusCode: statusCode)))
+            return
+        }
+
+        if let responseString = String(data: data, encoding: .utf8) {
+            message.append("\n\(responseString)\n")
+        }
+
+        do {
+            if Request.Response.self == VoidResponse.self {
+                Formbricks.logger?.info(message)
+                completion?(.success(VoidResponse() as! Request.Response))
+            } else {
+                var body = try request.decoder.decode(Request.Response.self, from: data)
+                if var env = body as? EnvironmentResponse, let jsonString = String(data: data, encoding: .utf8) {
+                    env.responseString = jsonString
+                    body = env as! Request.Response
+                }
+                Formbricks.logger?.info(message)
+                completion?(.success(body))
+            }
+        } catch {
+            handleDecodingError(error, message: &message, statusCode: statusCode)
+        }
+    }
+    
+    private func handleFailureResponse(data: Data?, error: Error?, statusCode: Int, message: String) {
+        var log = message
+
+        if let error = error {
+            log.append("\nError: \(error.localizedDescription)")
+            Formbricks.logger?.error(log)
+            completion?(.failure(error))
+        } else if let data = data, let apiError = try? request.decoder.decode(FormbricksAPIError.self, from: data) {
+            Formbricks.logger?.error("\(log)\n\(apiError.getDetailedErrorMessage())")
+            completion?(.failure(apiError))
+        } else {
+            let error = FormbricksAPIClientError(type: .responseError, statusCode: statusCode)
+            Formbricks.logger?.error("\(log)\n\(error.message)")
+            completion?(.failure(error))
+        }
+    }
+    
+    private func handleDecodingError(_ error: Error, message: inout String, statusCode: Int) {
+        switch error {
+        case let DecodingError.dataCorrupted(context):
+            message.append("Data corrupted: \(context)")
+        case let DecodingError.keyNotFound(key, context):
+            message.append("Key '\(key)' not found: \(context.debugDescription)\ncodingPath: \(context.codingPath)")
+        case let DecodingError.valueNotFound(value, context):
+            message.append("Value '\(value)' not found: \(context.debugDescription)\ncodingPath: \(context.codingPath)")
+        case let DecodingError.typeMismatch(type, context):
+            message.append("Type '\(type)' mismatch: \(context.debugDescription)\ncodingPath: \(context.codingPath)")
+        default:
+            message.append("Error: \(error.localizedDescription)")
+        }
+
+        Formbricks.logger?.error(message)
+        completion?(.failure(FormbricksAPIClientError(type: .invalidResponse, statusCode: statusCode)))
+    }
+    
+    private func logRequest(_ request: URLRequest) {
+        var message = "\(request.httpMethod ?? "") >>> \(request.url?.absoluteString ?? "")"
+        
+        if let headers = request.allHTTPHeaderFields {
+            message.append("\nHeaders: \(headers)")
+        }
+        
+        if let body = request.httpBody, let bodyString = String(data: body, encoding: .utf8) {
+            message.append("\nBody: \(bodyString)")
+        }
+
+        Formbricks.logger?.info(message)
+    }
+
 }
 
 private extension APIClient {

--- a/Sources/FormbricksSDK/Networking/Queue/UpdateQueue.swift
+++ b/Sources/FormbricksSDK/Networking/Queue/UpdateQueue.swift
@@ -61,6 +61,7 @@ final class UpdateQueue {
             } else {
                 // If no userId, just update locally without API call
                 Formbricks.logger?.debug("UpdateQueue - updating language locally: \(language)")
+                return
             }
             
             startDebounceTimer()

--- a/Sources/FormbricksSDK/WebView/SurveyWebView.swift
+++ b/Sources/FormbricksSDK/WebView/SurveyWebView.swift
@@ -54,15 +54,19 @@ struct SurveyWebView: UIViewRepresentable {
     func clean() {
         HTTPCookieStorage.shared.removeCookies(since: Date.distantPast)
         WKWebsiteDataStore.default().fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
-            records.forEach { record in
-                WKWebsiteDataStore.default().removeData(ofTypes: record.dataTypes, for: [record], completionHandler: {
-                    /*
-                     This completion handler is intentionally empty since we only need to 
-                     ensure the data is removed. No additional actions are required after
-                     the website data has been cleared.
-                    */
-                })
-            }
+            self.remove(records)
+        }
+    }
+    
+    private func remove(_ records: [WKWebsiteDataRecord]) {
+        records.forEach { record in
+            WKWebsiteDataStore.default().removeData(ofTypes: record.dataTypes, for: [record], completionHandler: {
+                /*
+                 This completion handler is intentionally empty since we only need to
+                 ensure the data is removed. No additional actions are required after
+                 the website data has been cleared.
+                */
+            })
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several updates to the `FormbricksSDK`, including a version bump, enhanced functionality for user management and API handling, and general codebase improvements. The most significant changes include adding language handling to user state, refactoring the `APIClient` for better readability and error handling, and improving the `SurveyWebView` structure for better maintainability.

### Version Update:
* Updated the SDK version to `1.0.1` in `FormbricksSDK.podspec` to reflect the new changes.

### User Management Enhancements:
* Added a check to prevent setting a new `userId` if one already exists, with an error message prompting the use of `Formbricks.logout()` first. (`Sources/FormbricksSDK/Formbricks.swift`)
* Introduced a `language` property to `UserStateDetails` and synchronized it with the server's language setting or reset it to "default" upon user logout. (`Sources/FormbricksSDK/Manager/UserManager.swift`, `Sources/FormbricksSDK/Model/User/UserStateDetails.swift`) [[1]](diffhunk://#diff-1f18934aa21221e0f9a71b986bd4a97b5ba9e3ea0c9d7fb41083e68ba933dc5cR98-R100) [[2]](diffhunk://#diff-1f18934aa21221e0f9a71b986bd4a97b5ba9e3ea0c9d7fb41083e68ba933dc5cR134-R140) [[3]](diffhunk://#diff-488075bd41d5620201d9d8f488e041153003425d8c319764a39d0616840e6010R10)

### API Client Refactoring:
* Refactored the `APIClient` to modularize URL building, request logging, and response handling, improving readability and maintainability. (`Sources/FormbricksSDK/Networking/Base/APIClient.swift`)

### WebView Improvements:
* Extracted cookie removal logic into a dedicated `remove` method to improve code clarity in `SurveyWebView`. (`Sources/FormbricksSDK/WebView/SurveyWebView.swift`) [[1]](diffhunk://#diff-cebc6b1b02eafc3ec21fc2f596d76d90e67b40e86d7069bc3992f918fb251cddR57-R61) [[2]](diffhunk://#diff-cebc6b1b02eafc3ec21fc2f596d76d90e67b40e86d7069bc3992f918fb251cddL68)

### Update Queue Fix:
* Added an early return in `UpdateQueue` when updating the language locally without an API call, preventing unnecessary operations. (`Sources/FormbricksSDK/Networking/Queue/UpdateQueue.swift`)