### PR TITLE
feat: adds pod publish action

### DIFF
--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -1,0 +1,36 @@
+name: Publish CocoaPod
+
+on:
+  push:
+    # runs on anything like v1.2.3
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish-pod:
+    runs-on: macos-latest
+    steps:
+      # 1. Check out your code
+      - uses: actions/checkout@v3
+
+      # 2. Install a recent Ruby
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.x
+
+      # 3. Install CocoaPods
+      - name: Install CocoaPods
+        run: |
+          gem install cocoapods
+
+      # 4. Authenticate with your CocoaPods Trunk token
+      - name: Configure CocoaPods Trunk Credentials
+        run: |
+          echo "machine trunk.cocoapods.org login $COCOAPODS_TRUNK_TOKEN" > ~/.netrc
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+
+      # 5. Push the podspec
+      - name: Push to CocoaPods Trunk
+        run: |
+          pod trunk push FormbricksSDK.podspec --allow-warnings --use-libraries


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the publishing of a CocoaPod. The workflow is triggered by version tag pushes and includes steps for setting up the environment, installing dependencies, and pushing the podspec to CocoaPods Trunk.

### New GitHub Actions Workflow:
* [`.github/workflows/publish-pod.yml`](diffhunk://#diff-f931f360b5bd40e96ec60e8e38af187189168a88d5adf5a69bed7cff2d8db9d3R1-R36): Added a workflow named `Publish CocoaPod` that runs on `macos-latest` and is triggered by version tag pushes (`v*.*.*`). The workflow includes steps for checking out the code, setting up Ruby, installing CocoaPods, configuring authentication with a CocoaPods Trunk token, and pushing the podspec to CocoaPods Trunk.