### PR TITLE
fix: publish pod action

### DIFF
--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -1,12 +1,7 @@
 name: Publish CocoaPod
 
 on:
-  workflow_dispatch:
-
   push:
-    branches:
-      - "**"
-    # runs on anything like v1.2.3
     tags:
       - "v*.*.*"
 

--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -1,6 +1,8 @@
 name: Publish CocoaPod
 
 on:
+  workflow_dispatch:
+
   push:
     # runs on anything like v1.2.3
     tags:
@@ -16,7 +18,7 @@ jobs:
       # 2. Install a recent Ruby
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.x
+          ruby-version: 3.4.3
 
       # 3. Install CocoaPods
       - name: Install CocoaPods

--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -2,6 +2,7 @@ name: Publish CocoaPod
 
 on:
   push:
+    # runs on anything like v1.2.3
     tags:
       - "v*.*.*"
 

--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -33,6 +33,6 @@ jobs:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
       # 5. Push the podspec
-      - name: Push to CocoaPods Trunk
-        run: |
-          pod trunk push FormbricksSDK.podspec --allow-warnings --use-libraries
+      # - name: Push to CocoaPods Trunk
+      #   run: |
+      #     pod trunk push FormbricksSDK.podspec --allow-warnings

--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
 
   push:
+    branches:
+      - "**"
     # runs on anything like v1.2.3
     tags:
       - "v*.*.*"

--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -30,6 +30,6 @@ jobs:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
       # 5. Push the podspec
-      # - name: Push to CocoaPods Trunk
-      #   run: |
-      #     pod trunk push FormbricksSDK.podspec --allow-warnings
+      - name: Push to CocoaPods Trunk
+        run: |
+          pod trunk push FormbricksSDK.podspec --allow-warnings


### PR DESCRIPTION
This pull request updates the CocoaPods publishing workflow in the `.github/workflows/publish-pod.yml` file. The changes focus on refining the workflow configuration, including updating the Ruby version, modifying the tag trigger comments, and adjusting the `pod trunk push` command.

### Workflow configuration updates:

* Updated the Ruby version used in the workflow from `3.x` to `3.4.3` to ensure compatibility with the latest features and fixes. (`[.github/workflows/publish-pod.ymlL19-R18](diffhunk://#diff-f931f360b5bd40e96ec60e8e38af187189168a88d5adf5a69bed7cff2d8db9d3L19-R18)`)
* Removed the `--use-libraries` flag from the `pod trunk push` command to simplify the publishing process, as it may no longer be necessary. (`[.github/workflows/publish-pod.ymlL36-R35](diffhunk://#diff-f931f360b5bd40e96ec60e8e38af187189168a88d5adf5a69bed7cff2d8db9d3L36-R35)`)
* Removed an outdated comment about tag triggers in the `on.push.tags` section for clarity. (`[.github/workflows/publish-pod.ymlL5](diffhunk://#diff-f931f360b5bd40e96ec60e8e38af187189168a88d5adf5a69bed7cff2d8db9d3L5)`)