### PR TITLE
fix: fixes pod publish github action's auth

### DIFF
--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -5,8 +5,6 @@ on:
     # runs on anything like v1.2.3
     tags:
       - "v*.*.*"
-    branches:
-      - "**"
 
 jobs:
   publish-pod:

--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -5,6 +5,8 @@ on:
     # runs on anything like v1.2.3
     tags:
       - "v*.*.*"
+    branches:
+      - "**"
 
 jobs:
   publish-pod:
@@ -23,14 +25,8 @@ jobs:
         run: |
           gem install cocoapods
 
-      # 4. Authenticate with your CocoaPods Trunk token
-      - name: Configure CocoaPods Trunk Credentials
-        run: |
-          echo "machine trunk.cocoapods.org login $COCOAPODS_TRUNK_TOKEN" > ~/.netrc
+      # 4. Push the podspec
+      - name: Publish to CocoaPods Trunk
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-
-      # 5. Push the podspec
-      - name: Push to CocoaPods Trunk
-        run: |
-          pod trunk push FormbricksSDK.podspec --allow-warnings
+        run: pod trunk push FormbricksSDK.podspec --allow-warnings

--- a/FormbricksSDK.podspec
+++ b/FormbricksSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FormbricksSDK"
-  s.version          = "1.0.1"                              
+  s.version          = "1.0.1-beta.1"                              
   s.summary          = "iOS SDK for Formbricks" 
   s.homepage         = "https://github.com/formbricks/ios"   
   s.license          = { :type => "MIT", :file => "LICENSE" }

--- a/FormbricksSDK.podspec
+++ b/FormbricksSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FormbricksSDK"
-  s.version          = "1.0.1-beta.1"                              
+  s.version          = "1.0.1"                              
   s.summary          = "iOS SDK for Formbricks" 
   s.homepage         = "https://github.com/formbricks/ios"   
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
This pull request simplifies the workflow for publishing to CocoaPods Trunk by consolidating and streamlining steps in the `.github/workflows/publish-pod.yml` file.

Workflow simplification:

* Removed the separate step for configuring CocoaPods Trunk credentials and combined it with the step for publishing the podspec. The `COCOAPODS_TRUNK_TOKEN` is now directly passed as an environment variable to the publish command. (`.github/workflows/publish-pod.yml`, [.github/workflows/publish-pod.ymlL26-R30](diffhunk://#diff-f931f360b5bd40e96ec60e8e38af187189168a88d5adf5a69bed7cff2d8db9d3L26-R30))