### PR TITLE
fix: sonarqube issue by using built-in URL type

### DIFF
--- a/Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift
+++ b/Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift
@@ -2,7 +2,7 @@ import Foundation
 
 internal enum FormbricksEnvironment {
 
-  /// Only `appUrl` is user-supplied. Crash early if it’s missing.
+  /// Only `appUrl` is user-supplied. Crash early if it's missing.
   fileprivate static var baseApiUrl: String {
     guard let url = Formbricks.appUrl else {
       fatalError("Formbricks.setup must be called before using the SDK.")
@@ -12,21 +12,23 @@ internal enum FormbricksEnvironment {
 
   /// Returns the full survey‐script URL as a String
   static var surveyScriptUrlString: String {
-    let path = "/" + ["js", "surveys.umd.cjs"].joined(separator: "/") // NOSONAR we can hard-code "/" here
-    return baseApiUrl + path
+    guard var components = URLComponents(string: baseApiUrl) else {
+      fatalError("Invalid base URL: \(baseApiUrl)")
+    }
+    
+    let pathComponents = components.path.split(separator: "/").map(String.init)
+    components.path = "/" + (pathComponents + ["js", "surveys.umd.cjs"]).joined(separator: "/")
+    
+    return components.string ?? baseApiUrl + "/js/surveys.umd.cjs"
   }
 
   /// Returns the full environment‐fetch URL as a String for the given ID
-    static var getEnvironmentRequestEndpoint: String {
-      let path = "/" + ["api", "v2", "client", "{environmentId}", "environment"] // NOSONAR we can hard-code "/" here
-      .joined(separator: "/")
-    return path
+  static var getEnvironmentRequestEndpoint: String {
+    return ["api", "v2", "client", "{environmentId}", "environment"].joined(separator: "/")
   }
 
   /// Returns the full post-user URL as a String for the given ID
-    static var postUserRequestEndpoint: String {
-    let path = "/" + ["api", "v2", "client", "{environmentId}", "user"] // NOSONAR we can hard-code "/" here
-      .joined(separator: "/")
-    return path
+  static var postUserRequestEndpoint: String {
+    return ["api", "v2", "client", "{environmentId}", "user"].joined(separator: "/")
   }
 }

--- a/Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift
+++ b/Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift
@@ -12,14 +12,13 @@ internal enum FormbricksEnvironment {
 
   /// Returns the full survey‐script URL as a String
   static var surveyScriptUrlString: String {
-    guard var components = URLComponents(string: baseApiUrl) else {
+    guard let baseURL = URL(string: baseApiUrl) else {
       fatalError("Invalid base URL: \(baseApiUrl)")
     }
     
-    let pathComponents = components.path.split(separator: "/").map(String.init)
-    components.path = "/" + (pathComponents + ["js", "surveys.umd.cjs"]).joined(separator: "/")
-    
-    return components.string ?? baseApiUrl + "/js/surveys.umd.cjs"
+    // Append path components properly using URL
+    let surveyScriptURL = baseURL.appendingPathComponent("js").appendingPathComponent("surveys.umd.cjs")
+    return surveyScriptURL.absoluteString
   }
 
   /// Returns the full environment‐fetch URL as a String for the given ID


### PR DESCRIPTION
This pull request refactors URL construction in the `FormbricksEnvironment` enum to improve clarity and maintainability. The changes include replacing manual string concatenation with `URLComponents` for constructing the `surveyScriptUrlString` and simplifying endpoint path definitions.

### Improvements to URL construction:

* [`Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift`](diffhunk://#diff-93d541943fc512cc9db2958ccb7d657affe3332482ed2472d3f41ee55520cd76L15-R32): Refactored `surveyScriptUrlString` to use `URLComponents` for constructing the URL, ensuring better handling of path components and edge cases. A fallback is provided in case of invalid components.

### Simplification of endpoint definitions:

* [`Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift`](diffhunk://#diff-93d541943fc512cc9db2958ccb7d657affe3332482ed2472d3f41ee55520cd76L15-R32): Simplified the `getEnvironmentRequestEndpoint` and `postUserRequestEndpoint` by removing redundant `"/"` concatenation and directly joining path components with `"/"`.

### Minor stylistic change:

* [`Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift`](diffhunk://#diff-93d541943fc512cc9db2958ccb7d657affe3332482ed2472d3f41ee55520cd76L5-R5): Updated a comment to standardize the use of single quotes in "it's" for consistency.