### PR TITLE
chore: adds some tests

### DIFF
--- a/Sources/FormbricksSDK/Networking/Base/APIClient.swift
+++ b/Sources/FormbricksSDK/Networking/Base/APIClient.swift
@@ -2,12 +2,13 @@ import Foundation
 
 class APIClient<Request: CodableRequest>: Operation, @unchecked Sendable {
     
-    private let session = URLSession.shared
+    private let session: URLSession
     private let request: Request
     private let completion: ((ResultType<Request.Response>) -> Void)?
     
-    init(request: Request, completion: ((ResultType<Request.Response>) -> Void)?) {
+    init(request: Request, session: URLSession = .shared, completion: ((ResultType<Request.Response>) -> Void)?) {
         self.request = request
+        self.session = session
         self.completion = completion
     }
     

--- a/Tests/FormbricksSDKTests/Networking/APIClientTests.swift
+++ b/Tests/FormbricksSDKTests/Networking/APIClientTests.swift
@@ -1,0 +1,383 @@
+import XCTest
+@testable import FormbricksSDK
+
+final class APIClientTests: XCTestCase {
+    
+    // MARK: - Test Doubles
+    
+    private struct MockRequest: CodableRequest {
+        typealias Response = MockResponse
+        
+        var baseURL: String?
+        var requestEndPoint: String
+        var requestType: HTTPMethod
+        var headers: [String: String]?
+        var queryParams: [String: String]?
+        var pathParams: [String: String]?
+        var requestBody: Data?
+        
+        var decoder: JSONDecoder {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return decoder
+        }
+    }
+    
+    private struct MockResponse: Codable {
+        let id: String
+        let name: String
+    }
+    
+    private struct MockEnvironmentResponse: Codable {
+        var responseString: String?
+        let id: String
+        let name: String
+    }
+    
+    // MARK: - Properties
+    
+    private var mockURLSession: MockURLSession!
+    private var sut: APIClient<MockRequest>!
+    
+    // MARK: - Setup & Teardown
+    
+    override func setUp() {
+        super.setUp()
+        mockURLSession = MockURLSession()
+        Formbricks.environmentId = "test-env-id"
+    }
+    
+    override func tearDown() {
+        mockURLSession = nil
+        sut = nil
+        Formbricks.environmentId = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Test Cases
+    
+    func testSuccessfulResponse() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes")
+        let mockResponse = MockResponse(id: "123", name: "Test")
+        let responseData = try! JSONEncoder().encode(mockResponse)
+        
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test/{environmentId}",
+            requestType: .get
+        )
+        
+        mockURLSession.mockData = responseData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.id, "123")
+                XCTAssertEqual(response.name, "Test")
+            case .failure(let error):
+                XCTFail("Expected success but got error: \(error)")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testFailedResponseWithAPIError() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes")
+        let apiError = FormbricksAPIError(
+            code: "TEST_ERROR",
+            message: "Test error",
+            details: ["field": "test_field"]
+        )
+        let errorData = try! JSONEncoder().encode(apiError)
+        
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        mockURLSession.mockData = errorData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 400,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .success:
+                XCTFail("Expected failure but got success")
+            case .failure(let error as FormbricksAPIError):
+                XCTAssertEqual(error.message, "Test error")
+                XCTAssertEqual(error.code, "TEST_ERROR")
+                XCTAssertEqual(error.details?["field"], "test_field")
+            case .failure(let error):
+                XCTFail("Expected FormbricksAPIError but got: \(type(of: error))")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testInvalidURL() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes")
+        let request = MockRequest(
+            baseURL: nil,
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .success:
+                XCTFail("Expected failure but got success")
+            case .failure(let error as FormbricksSDKError):
+                XCTAssertEqual(error.type, .sdkIsNotInitialized)
+            case .failure(let error):
+                XCTFail("Expected FormbricksSDKError but got: \(type(of: error))")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testDecodingError() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes")
+        let invalidData = "invalid json".data(using: .utf8)!
+        
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        mockURLSession.mockData = invalidData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .success:
+                XCTFail("Expected failure but got success")
+            case .failure(let error as FormbricksAPIClientError):
+                XCTAssertEqual(error.type, .invalidResponse)
+            case .failure(let error):
+                XCTFail("Expected FormbricksAPIClientError but got: \(type(of: error))")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testVoidResponse() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes")
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        mockURLSession.mockData = "{}".data(using: .utf8)
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .success:
+                XCTAssertTrue(true)
+            case .failure(let error):
+                let normalized = error.localizedDescription
+                    .replacingOccurrences(of: "’", with: "'") // curly to straight apostrophe
+                    .replacingOccurrences(of: "‘", with: "'") // opening curly to straight
+                    .lowercased() // optional: ignore case
+
+                XCTAssertTrue(normalized.contains("couldn't be completed"))
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testNetworkError() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes")
+        let networkError = NSError(domain: "test", code: -1009, userInfo: [NSLocalizedDescriptionKey: "No internet connection"])
+        
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        mockURLSession.mockError = networkError
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 0,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .success:
+                XCTFail("Expected failure but got success")
+            case .failure(let error):
+                let normalized = error.localizedDescription
+                    .replacingOccurrences(of: "’", with: "'") // curly to straight apostrophe
+                    .replacingOccurrences(of: "‘", with: "'") // opening curly to straight
+                    .lowercased() // optional: ignore case
+
+                XCTAssertTrue(normalized.contains("couldn't be completed"))
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testRequestWithQueryParams() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes")
+        let mockResponse = MockResponse(id: "123", name: "Test")
+        let responseData = try! JSONEncoder().encode(mockResponse)
+        
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get,
+            queryParams: ["key": "value", "filter": "active"]
+        )
+        
+        mockURLSession.mockData = responseData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.id, "123")
+                XCTAssertEqual(response.name, "Test")
+            case .failure(let error):
+                XCTFail("Expected success but got error: \(error)")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testRequestWithHeaders() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes")
+        let mockResponse = MockResponse(id: "123", name: "Test")
+        let responseData = try! JSONEncoder().encode(mockResponse)
+        
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get,
+            headers: ["Authorization": "Bearer token", "Content-Type": "application/json"]
+        )
+        
+        mockURLSession.mockData = responseData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.id, "123")
+                XCTAssertEqual(response.name, "Test")
+            case .failure(let error):
+                XCTFail("Expected success but got error: \(error)")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+
+// MARK: - Mock URLSession
+
+private class MockURLSession: URLSession {
+    var mockData: Data?
+    var mockResponse: URLResponse?
+    var mockError: Error?
+    
+    override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        return MockURLSessionDataTask {
+            completionHandler(self.mockData, self.mockResponse, self.mockError)
+        }
+    }
+}
+
+private class MockURLSessionDataTask: URLSessionDataTask {
+    private let completion: () -> Void
+    
+    init(completion: @escaping () -> Void) {
+        self.completion = completion
+    }
+    
+    override func resume() {
+        completion()
+    }
+} 

--- a/Tests/FormbricksSDKTests/Networking/ClientAPIEndpointsTests.swift
+++ b/Tests/FormbricksSDKTests/Networking/ClientAPIEndpointsTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import FormbricksSDK
+
+final class GetEnvironmentRequestTests: XCTestCase {
+    func testInit() {
+        let req = GetEnvironmentRequest()
+        XCTAssertEqual(req.requestType, .get)
+        XCTAssertFalse(req.requestEndPoint.isEmpty)
+    }
+}
+
+final class PostUserRequestTests: XCTestCase {
+    func testInit() {
+        let req = PostUserRequest(userId: "abc", attributes: ["foo": "bar"])
+        XCTAssertEqual(req.requestType, .post)
+        XCTAssertFalse(req.requestEndPoint.isEmpty)
+    }
+}

--- a/Tests/FormbricksSDKTests/Networking/UpdateQueueTests.swift
+++ b/Tests/FormbricksSDKTests/Networking/UpdateQueueTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import FormbricksSDK
+
+class MockUserManager: UserManagerSyncable {
+    var lastSyncedUserId: String?
+    var lastSyncedAttributes: [String: String]?
+    var syncCallCount = 0
+    func syncUser(withId id: String, attributes: [String : String]?) {
+        lastSyncedUserId = id
+        lastSyncedAttributes = attributes
+        syncCallCount += 1
+    }
+}
+
+final class UpdateQueueTests: XCTestCase {
+    var queue: UpdateQueue!
+    var mockUserManager: MockUserManager!
+    
+    override func setUp() {
+        super.setUp()
+        mockUserManager = MockUserManager()
+        queue = UpdateQueue(userManager: mockUserManager)
+    }
+    
+    override func tearDown() {
+        queue.cleanup()
+        queue = nil
+        mockUserManager = nil
+        super.tearDown()
+    }
+    
+    func testSetUserIdTriggersDebounceAndCommit() {
+        let exp = expectation(description: "Debounce triggers commit")
+        queue.set(userId: "user123")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            XCTAssertEqual(self.mockUserManager.lastSyncedUserId, "user123")
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    func testSetAttributesTriggersDebounceAndCommit() {
+        let exp = expectation(description: "Debounce triggers commit for attributes")
+        queue.set(userId: "user123")
+        queue.set(attributes: ["foo": "bar"])
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            XCTAssertEqual(self.mockUserManager.lastSyncedAttributes?["foo"], "bar")
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    func testAddAttributeToExisting() {
+        let exp = expectation(description: "Add attribute to existing attributes")
+        queue.set(userId: "user123")
+        queue.set(attributes: ["foo": "bar"])
+        queue.add(attribute: "baz", forKey: "newKey")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            XCTAssertEqual(self.mockUserManager.lastSyncedAttributes?["foo"], "bar")
+            XCTAssertEqual(self.mockUserManager.lastSyncedAttributes?["newKey"], "baz")
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    func testAddAttributeToNew() {
+        let exp = expectation(description: "Add attribute to new attributes")
+        queue.set(userId: "user123")
+        queue.add(attribute: "baz", forKey: "newKey")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            XCTAssertEqual(self.mockUserManager.lastSyncedAttributes?["newKey"], "baz")
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    func testSetLanguageWithUserId() {
+        let exp = expectation(description: "Set language with userId triggers commit")
+        queue.set(userId: "user123")
+        queue.set(language: "de")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            XCTAssertEqual(self.mockUserManager.lastSyncedAttributes?["language"], "de")
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    func testSetLanguageWithoutUserId() {
+        // Should not call syncUser, just log
+        queue.set(language: "fr")
+        let exp = expectation(description: "No commit without userId")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            XCTAssertEqual(self.mockUserManager.syncCallCount, 0)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    func testResetClearsState() {
+        queue.set(userId: "user123")
+        queue.set(attributes: ["foo": "bar"])
+        queue.set(language: "en")
+        queue.reset()
+        // Internal state is private, but we can check that no sync happens after reset
+        let exp = expectation(description: "No commit after reset")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            // Should not have called syncUser after reset
+            XCTAssertNil(self.mockUserManager.lastSyncedUserId)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    func testCleanupStopsTimerAndClearsState() {
+        queue.set(userId: "user123")
+        queue.set(attributes: ["foo": "bar"])
+        queue.cleanup()
+        let exp = expectation(description: "No commit after cleanup")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            XCTAssertNil(self.mockUserManager.lastSyncedUserId)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    func testCommitWithoutUserIdLogsError() {
+        // This will not call syncUser, but will log an error
+        queue.set(attributes: ["foo": "bar"])
+        let exp = expectation(description: "No commit without userId")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            XCTAssertNil(self.mockUserManager.lastSyncedUserId)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+} 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,7 +15,7 @@ sonar.exclusions=**/Mock/**,**/*.xcodeproj/**,**/.swiftpm/**
 
 #— (Optional) Test File Inclusions —#
 # if you want Sonar to know which files are tests
-sonar.coverage.exclusions=**/Model/**,**/Helpers/AnyCodable/**,**/WebView/**
+sonar.coverage.exclusions=**/Networking/Base/HTTPStatusCode.swift,**/Networking/Base/EncodableRequest.swift,**/Model/**,**/Helpers/AnyCodable/**,**/WebView/**
 
 #— Encoding & Language —#
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
This pull request introduces several updates to the `FormbricksSDK` codebase, focusing on improving test coverage, enhancing the flexibility of the `APIClient`, and refining the SonarQube configuration. The most notable changes include making the `URLSession` injectable for testing, adding comprehensive unit tests for `APIClient` and other components, and updating SonarQube exclusions. 

### Enhancements to `APIClient`:

* Made `URLSession` injectable by adding a `session` parameter to the `APIClient` initializer, defaulting to `.shared`. This change improves testability by allowing the use of mock sessions during testing. (`Sources/FormbricksSDK/Networking/Base/APIClient.swift`, [Sources/FormbricksSDK/Networking/Base/APIClient.swiftL5-R11](diffhunk://#diff-9d7f3602e3bc79409802e96ceee79c0cf311f24e35445874ea229a4b41bdab2eL5-R11))

### Expanded Test Coverage:

* Added a new `APIClientTests` test suite with multiple test cases for various scenarios, including successful responses, API errors, invalid URLs, decoding errors, and network errors. A `MockURLSession` was introduced to simulate network requests. (`Tests/FormbricksSDKTests/Networking/APIClientTests.swift`, [Tests/FormbricksSDKTests/Networking/APIClientTests.swiftR1-R383](diffhunk://#diff-cfdb58c70a16747d0425a2d5719657fa7dfff81d7a3de179d4c00ac8109845c3R1-R383))
* Introduced unit tests for specific API request classes, such as `GetEnvironmentRequest` and `PostUserRequest`, to validate their initialization and properties. (`Tests/FormbricksSDKTests/Networking/ClientAPIEndpointsTests.swift`, [Tests/FormbricksSDKTests/Networking/ClientAPIEndpointsTests.swiftR1-R18](diffhunk://#diff-7dcf6a0a94017016b609718c7338d3451aba1375c336b589bb2f07ce4b61e56fR1-R18))
* Added `UpdateQueueTests` to verify the behavior of the `UpdateQueue` class, including debouncing, attribute updates, and state resets, using a `MockUserManager` for assertions. (`Tests/FormbricksSDKTests/Networking/UpdateQueueTests.swift`, [Tests/FormbricksSDKTests/Networking/UpdateQueueTests.swiftR1-R136](diffhunk://#diff-4086bbd2db8f78e99eb93cdc45673c7f8ee61bd154e355fb52ec126b5b25b220R1-R136))

### SonarQube Configuration:

* Updated `sonar.coverage.exclusions` to exclude additional files (`HTTPStatusCode.swift` and `EncodableRequest.swift`) from coverage analysis, ensuring a more focused code quality assessment. (`sonar-project.properties`, [sonar-project.propertiesL18-R18](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL18-R18))