### PR TITLE
chore: exclude 3rd party code from line duplication

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,7 @@
+# Exclude AnyCodable helper files from duplication analysis
+# Reason: These files are derived from the open-source Flight-School/AnyCodable library (https://github.com/Flight-School/AnyCodable) and are considered vendor/third-party code. Refactoring or modifying them would make it difficult to update from upstream and is not recommended. Excluding them from duplication checks is a standard practice for vendor code, as we are not responsible for their structure or code quality.
+sonar.cpd.exclusions=Sources/FormbricksSDK/Helpers/AnyCodable/*.swift
+
 sonar.projectKey=formbricks_ios
 sonar.organization=formbricks
 


### PR DESCRIPTION
This pull request updates the SonarQube configuration to exclude specific third-party files from duplication analysis.

We are excluding the AnyCodable helper files from SonarQube's duplicated lines analysis because these files are derived from the open-source Flight-School/AnyCodable library (https://github.com/Flight-School/AnyCodable) and are considered vendor/third-party code. Refactoring or modifying them would make it difficult to update from the upstream source and is not recommended. Excluding such files from duplication checks is a standard practice for vendor code, as we are not responsible for their structure or code quality.

Configuration updates:

* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cR1-R4): Added `sonar.cpd.exclusions` to exclude `Sources/FormbricksSDK/Helpers/AnyCodable/*.swift` from duplication checks. These files are derived from the open-source `Flight-School/AnyCodable` library and are considered vendor code, making them unsuitable for refactoring or modification.