### PR TITLE
chore: add more tests to survey manager

### DIFF
--- a/Sources/FormbricksSDK/Manager/SurveyManager.swift
+++ b/Sources/FormbricksSDK/Manager/SurveyManager.swift
@@ -168,7 +168,7 @@ private extension SurveyManager {
     }
     
     /// Refreshes the environment state after the given timeout.
-    func refreshEnvironmentAfter(timeout: Double) {
+    internal func refreshEnvironmentAfter(timeout: Double) {
         guard timeout > 0 else {
             return
         }
@@ -180,7 +180,7 @@ private extension SurveyManager {
     }
     
     /// Decides if the survey should be displayed based on the display percentage.
-    func shouldDisplayBasedOnPercentage(_ displayPercentage: Double?) -> Bool {
+    internal func shouldDisplayBasedOnPercentage(_ displayPercentage: Double?) -> Bool {
         guard let displayPercentage = displayPercentage else { return true }
         let randomNum = Double(Int.random(in: 0..<10000)) / 100.0
         return randomNum <= displayPercentage
@@ -215,7 +215,7 @@ extension SurveyManager {
 }
 
 // MARK: - Helper methods -
-private extension SurveyManager {
+extension SurveyManager {
     /// Filters the surveys based on the display type and limit.
     func filterSurveysBasedOnDisplayType(_ surveys: [Survey], displays: [Display], responses: [String]) -> [Survey] {
         return surveys.filter { survey in
@@ -263,7 +263,7 @@ private extension SurveyManager {
         }
     }
     
-    func getLanguageCode(
+    internal func getLanguageCode(
         survey: Survey,
         language: String?
     ) -> String? {


### PR DESCRIPTION
This pull request introduces changes to the `SurveyManager` class and its test coverage in the `FormbricksSDK`. The key updates include modifying access levels for methods, refactoring helper methods, and adding comprehensive test cases to improve code reliability and maintainability.

### Changes to `SurveyManager`:

* Updated method access levels from `private` to `internal` for `refreshEnvironmentAfter`, `shouldDisplayBasedOnPercentage`, and `getLanguageCode` to allow broader access within the module. [[1]](diffhunk://#diff-f15df4851352e3c8871c2f41be5825227bdc59c5fc26f78c808bda6fd803bb33L171-R171) [[2]](diffhunk://#diff-f15df4851352e3c8871c2f41be5825227bdc59c5fc26f78c808bda6fd803bb33L183-R183) [[3]](diffhunk://#diff-f15df4851352e3c8871c2f41be5825227bdc59c5fc26f78c808bda6fd803bb33L266-R266)
* Refactored helper methods by moving them from `private extension SurveyManager` to `extension SurveyManager`, making them accessible as part of the main class extension.

### Test Coverage Enhancements:

* Added a new test case, `testSurveyManagerEdgeCases`, in `FormbricksSDKTests` to cover edge scenarios for `SurveyManager`. This includes testing:
  - `shouldDisplayBasedOnPercentage` for various input values.
  - Handling of corrupt `UserDefaults` data.
  - Timer-based refresh functionality.
  - Comprehensive coverage of `getLanguageCode` with different language configurations.