### PR TITLE
chore: add tests for new code in formbricks environment

### DIFF
--- a/Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift
+++ b/Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift
@@ -2,21 +2,18 @@ import Foundation
 
 internal enum FormbricksEnvironment {
 
-  /// Only `appUrl` is user-supplied. Crash early if it's missing.
-  fileprivate static var baseApiUrl: String {
-    guard let url = Formbricks.appUrl else {
-      fatalError("Formbricks.setup must be called before using the SDK.")
-    }
-    return url
+  /// Only `appUrl` is user-supplied. Returns nil if it's missing.
+  internal static var baseApiUrl: String? {
+    return Formbricks.appUrl
   }
 
   /// Returns the full survey‐script URL as a String
-  static var surveyScriptUrlString: String {
-    guard let baseURL = URL(string: baseApiUrl) else {
-      fatalError("Invalid base URL: \(baseApiUrl)")
+  static var surveyScriptUrlString: String? {
+    guard let baseURLString = baseApiUrl,
+          let baseURL = URL(string: baseURLString),
+          baseURL.scheme == "https" || baseURL.scheme == "http" else {
+      return nil
     }
-    
-    // Append path components properly using URL
     let surveyScriptURL = baseURL.appendingPathComponent("js").appendingPathComponent("surveys.umd.cjs")
     return surveyScriptURL.absoluteString
   }

--- a/Sources/FormbricksSDK/WebView/FormbricksViewModel.swift
+++ b/Sources/FormbricksSDK/WebView/FormbricksViewModel.swift
@@ -8,8 +8,10 @@ final class FormbricksViewModel: ObservableObject {
     
     init(environmentResponse: EnvironmentResponse, surveyId: String) {
         self.surveyId = surveyId
-        if let webviewDataJson = WebViewData(environmentResponse: environmentResponse, surveyId: surveyId).getJsonString() {
+        if let webviewDataJson = WebViewData(environmentResponse: environmentResponse, surveyId: surveyId).getJsonString(),
+           let surveyScriptUrl = FormbricksEnvironment.surveyScriptUrlString {
             htmlString = htmlTemplate.replacingOccurrences(of: "{{WEBVIEW_DATA}}", with: webviewDataJson)
+                .replacingOccurrences(of: "{{SURVEY_SCRIPT_URL}}", with: surveyScriptUrl)
         }
     }
 }
@@ -64,7 +66,7 @@ private extension FormbricksViewModel {
                 }
 
                 const script = document.createElement("script");
-                script.src = "\(FormbricksEnvironment.surveyScriptUrlString)";
+                script.src = "{{SURVEY_SCRIPT_URL}}";
                 script.async = true;
                 script.onload = () => loadSurvey();
                 script.onerror = (error) => {

--- a/Tests/FormbricksSDKTests/FormbricksEnvironmentTests.swift
+++ b/Tests/FormbricksSDKTests/FormbricksEnvironmentTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import FormbricksSDK
+
+final class FormbricksEnvironmentTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Always clean up before each test
+        Formbricks.cleanup()
+    }
+    
+    override func tearDown() {
+        Formbricks.cleanup()
+        super.tearDown()
+    }
+    
+    func testBaseApiUrl() {
+        // Test that baseApiUrl returns nil when appUrl is nil
+        XCTAssertNil(FormbricksEnvironment.baseApiUrl)
+        
+        // Setup SDK with valid appUrl
+        Formbricks.setup(with: FormbricksConfig.Builder(appUrl: "https://app.formbricks.com", environmentId: "test-env-id")
+            .setLogLevel(.debug)
+            .build())
+        
+        // Test that baseApiUrl returns the correct URL
+        XCTAssertEqual(FormbricksEnvironment.baseApiUrl, "https://app.formbricks.com")
+    }
+    
+    func testSurveyScriptUrlString() {
+        // Test that surveyScriptUrlString returns nil when appUrl is nil
+        XCTAssertNil(FormbricksEnvironment.surveyScriptUrlString)
+        
+        // Setup SDK with valid appUrl
+        Formbricks.setup(with: FormbricksConfig.Builder(appUrl: "https://app.formbricks.com", environmentId: "test-env-id")
+            .setLogLevel(.debug)
+            .build())
+        
+        // Test that surveyScriptUrlString returns the correct URL
+        XCTAssertEqual(FormbricksEnvironment.surveyScriptUrlString, "https://app.formbricks.com/js/surveys.umd.cjs")
+        
+        // Test with invalid URL
+        Formbricks.cleanup()
+        Formbricks.setup(with: FormbricksConfig.Builder(appUrl: "invalid url", environmentId: "test-env-id")
+            .setLogLevel(.debug)
+            .build())
+        
+        // Test that surveyScriptUrlString returns nil for invalid URL
+        XCTAssertNil(FormbricksEnvironment.surveyScriptUrlString)
+    }
+} 

--- a/Tests/FormbricksSDKTests/FormbricksSDKTests.swift
+++ b/Tests/FormbricksSDKTests/FormbricksSDKTests.swift
@@ -221,13 +221,13 @@ final class FormbricksSDKTests: XCTestCase {
         UserDefaults.standard.set(Data([0x00, 0x01]), forKey: "environmentResponseObjectKey")
         XCTAssertNil(manager.environmentResponse)
 
-        // Timer-based refresh (simulate with short timeout)
-        manager.refreshEnvironmentAfter(timeout: 0.01)
+        // Timer-based refresh (use more generous timeouts)
+        manager.refreshEnvironmentAfter(timeout: 0.1)
         let expectation = XCTestExpectation(description: "Timer fired")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 0.1)
+        wait(for: [expectation], timeout: 1.0)
 
         // getLanguageCode coverage
         let survey = Survey(


### PR DESCRIPTION
This pull request refactors the `FormbricksEnvironment` to improve robustness by replacing fatal errors with optional returns, updates the `FormbricksViewModel` to integrate these changes, and adds comprehensive unit tests for the new behavior. The most important changes are detailed below.

### Refactoring `FormbricksEnvironment`

* Updated `baseApiUrl` to return `nil` instead of crashing when `appUrl` is missing, improving error handling. (`Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift`, [Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swiftL5-L19](diffhunk://#diff-93d541943fc512cc9db2958ccb7d657affe3332482ed2472d3f41ee55520cd76L5-L19))
* Modified `surveyScriptUrlString` to return `nil` for invalid or missing `appUrl` and added validation for HTTPS/HTTP schemes. (`Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swift`, [Sources/FormbricksSDK/Helpers/FormbricksEnvironment.swiftL5-L19](diffhunk://#diff-93d541943fc512cc9db2958ccb7d657affe3332482ed2472d3f41ee55520cd76L5-L19))

### Updates to `FormbricksViewModel`

* Updated the `htmlString` generation to replace a new placeholder, `{{SURVEY_SCRIPT_URL}}`, with the value of `surveyScriptUrlString`. (`Sources/FormbricksSDK/WebView/FormbricksViewModel.swift`, [Sources/FormbricksSDK/WebView/FormbricksViewModel.swiftL11-R14](diffhunk://#diff-85f7d1f20685cf85aba9ce87b1fcaf2af18dbf7b0c483c4d99ecfb0deaaa1cd3L11-R14))
* Replaced hardcoded `surveyScriptUrlString` in the JavaScript template with the `{{SURVEY_SCRIPT_URL}}` placeholder for consistency. (`Sources/FormbricksSDK/WebView/FormbricksViewModel.swift`, [Sources/FormbricksSDK/WebView/FormbricksViewModel.swiftL67-R69](diffhunk://#diff-85f7d1f20685cf85aba9ce87b1fcaf2af18dbf7b0c483c4d99ecfb0deaaa1cd3L67-R69))

### Unit Tests

* Added `FormbricksEnvironmentTests` to test the behavior of `baseApiUrl` and `surveyScriptUrlString`, ensuring they return the correct values or `nil` for invalid inputs. (`Tests/FormbricksSDKTests/FormbricksEnvironmentTests.swift`, [Tests/FormbricksSDKTests/FormbricksEnvironmentTests.swiftR1-R51](diffhunk://#diff-8e03be32716465b0135849b384d7041c5dbf5da8bcdc892e9ddc087e0198d796R1-R51))