### PR TITLE
chore: changes version number for release

### DIFF
--- a/FormbricksSDK.podspec
+++ b/FormbricksSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FormbricksSDK"
-  s.version          = "1.1.0"                              
+  s.version          = "1.0.2"                              
   s.summary          = "iOS SDK for Formbricks" 
   s.homepage         = "https://github.com/formbricks/ios"   
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
This pull request includes a single change to the `FormbricksSDK.podspec` file. The version of the `FormbricksSDK` has been downgraded from `1.1.0` to `1.0.2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version number of the FormbricksSDK to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->