### PR TITLE
fix: recontact days calculation

### DIFF
--- a/Sources/FormbricksSDK/Extension/Calendar+DaysBetween.swift
+++ b/Sources/FormbricksSDK/Extension/Calendar+DaysBetween.swift
@@ -7,6 +7,7 @@ extension Calendar {
         let toDate = startOfDay(for: to)
         let numberOfDays = dateComponents([.day], from: fromDate, to: toDate)
         
-        return abs(numberOfDays.day! + 1)
+        guard let day = numberOfDays.day else { return 0 }
+        return abs(day + 1)
     }
 }

--- a/Sources/FormbricksSDK/Extension/Calendar+DaysBetween.swift
+++ b/Sources/FormbricksSDK/Extension/Calendar+DaysBetween.swift
@@ -7,6 +7,6 @@ extension Calendar {
         let toDate = startOfDay(for: to)
         let numberOfDays = dateComponents([.day], from: fromDate, to: toDate)
         
-        return numberOfDays.day! + 1
+        return abs(numberOfDays.day! + 1)
     }
 }


### PR DESCRIPTION
This pull request includes a small but important fix to the `Calendar` extension in `Sources/FormbricksSDK/Extension/Calendar+DaysBetween.swift`. The change ensures that the `daysBetween` calculation always returns a positive value by applying the `abs` function to the result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- The calculation for the number of days between two dates now always returns a non-negative value, regardless of the order of the dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->