### PR TITLE
fix: webview scroll issue

### DIFF
--- a/Sources/FormbricksSDK/WebView/FormbricksViewModel.swift
+++ b/Sources/FormbricksSDK/WebView/FormbricksViewModel.swift
@@ -52,10 +52,16 @@ private extension FormbricksViewModel {
                     window.webkit.messageHandlers.jsMessage.postMessage(JSON.stringify({ event: "onOpenExternalURL", onOpenExternalURLParams: { url: url } }));
                 };
 
+                let setResponseFinished = null;
+                function getSetIsResponseSendingFinished(callback) {
+                    setResponseFinished = callback;
+                }  
+
                 function loadSurvey() {
                     const options = JSON.parse(json);
                     surveyProps = {
                         ...options,
+                        getSetIsResponseSendingFinished,
                         onDisplayCreated,
                         onResponseCreated,
                         onClose,

--- a/Sources/FormbricksSDK/WebView/SurveyWebView.swift
+++ b/Sources/FormbricksSDK/WebView/SurveyWebView.swift
@@ -30,6 +30,7 @@ struct SurveyWebView: UIViewRepresentable {
         }
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
+        webView.scrollView.isScrollEnabled = false
         return webView
     }
     


### PR DESCRIPTION
This pull request introduces enhancements to the `FormbricksSDK` to improve survey handling and user experience. The most important changes include adding functionality to track response submission status and disabling scrolling in the survey web view.

### Enhancements to survey handling:

* [`Sources/FormbricksSDK/WebView/FormbricksViewModel.swift`](diffhunk://#diff-85f7d1f20685cf85aba9ce87b1fcaf2af18dbf7b0c483c4d99ecfb0deaaa1cd3R55-R64): Added a `getSetIsResponseSendingFinished` function to enable tracking of response submission status, along with a `setResponseFinished` callback. Integrated this functionality into the `surveyProps` object.

### Improvements to user experience:

* [`Sources/FormbricksSDK/WebView/SurveyWebView.swift`](diffhunk://#diff-cebc6b1b02eafc3ec21fc2f596d76d90e67b40e86d7069bc3992f918fb251cddR33): Disabled scrolling in the survey web view by setting `webView.scrollView.isScrollEnabled` to `false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved survey integration by enabling custom handling of survey response completion.
- **Style**
  - Disabled scrolling within the embedded survey view for a more streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->