### PR TITLE
fix: blocks http requests

### DIFF
--- a/Sources/FormbricksSDK/Formbricks.swift
+++ b/Sources/FormbricksSDK/Formbricks.swift
@@ -56,14 +56,20 @@ import Network
         self.environmentId = config.environmentId
         self.logger?.logLevel = config.logLevel
         
-        let svc: FormbricksServiceProtocol = config.customService
-                ?? {
-                    guard URL(string: config.appUrl) != nil else {
-                        fatalError("Invalid appUrl")
-                    }
-                    
-                    return FormbricksService()
-                }()
+        // Validate appUrl before proceeding with setup
+        guard let url = URL(string: config.appUrl) else {
+            let error = FormbricksSDKError(type: .invalidAppUrl)
+            fatalError("Invalid appUrl: \(config.appUrl). SDK setup aborted.")
+        }
+        
+        // Validate that appUrl uses HTTPS (block HTTP for security)
+        guard url.scheme?.lowercased() == "https" else {
+            let errorMessage = "HTTP requests are blocked for security. Only HTTPS URLs are allowed. Provided app url: \(config.appUrl). SDK setup aborted."
+            Formbricks.logger?.error(errorMessage)
+            return
+        }
+        
+        let svc: FormbricksServiceProtocol = config.customService ?? FormbricksService()
         
         userManager = UserManager()
         userManager?.service = svc

--- a/Sources/FormbricksSDK/Formbricks.swift
+++ b/Sources/FormbricksSDK/Formbricks.swift
@@ -59,7 +59,8 @@ import Network
         // Validate appUrl before proceeding with setup
         guard let url = URL(string: config.appUrl) else {
             let error = FormbricksSDKError(type: .invalidAppUrl)
-            fatalError("Invalid appUrl: \(config.appUrl). SDK setup aborted.")
+            Formbricks.logger?.error("Invalid appUrl: \(config.appUrl). SDK setup aborted.")
+            return
         }
         
         // Validate that appUrl uses HTTPS (block HTTP for security)

--- a/Sources/FormbricksSDK/Manager/SurveyManager.swift
+++ b/Sources/FormbricksSDK/Manager/SurveyManager.swift
@@ -26,8 +26,6 @@ final class SurveyManager {
             )
         }
     
-//    internal var service = FormbricksService()
-    
     private static let environmentResponseObjectKey = "environmentResponseObjectKey"
     private var backingEnvironmentResponse: EnvironmentResponse?
     /// Stores the surveys that are filtered based on the defined criteria, such as recontact days, display options etc.
@@ -311,5 +309,4 @@ extension SurveyManager {
             return segments.contains(segmentId)
         }
     }
-    
 }

--- a/Sources/FormbricksSDK/Networking/Base/APIClient.swift
+++ b/Sources/FormbricksSDK/Networking/Base/APIClient.swift
@@ -29,6 +29,14 @@ class APIClient<Request: CodableRequest>: Operation, @unchecked Sendable {
     private func buildFinalURL() -> URL? {
         guard let apiURL = request.baseURL, var components = URLComponents(string: apiURL) else { return nil }
         
+        // Ensure only HTTPS requests are allowed (block HTTP)
+        guard let scheme = components.scheme?.lowercased(), scheme == "https" else {
+            let errorMessage = "HTTP requests are blocked for security. Only HTTPS requests are allowed. Provided app url: \(apiURL)"
+            Formbricks.logger?.error(errorMessage)
+            completion?(.failure(FormbricksSDKError(type: .invalidAppUrl)))
+            return nil
+        }
+        
         components.queryItems = request.queryParams?.map { URLQueryItem(name: $0.key, value: $0.value) }
         
         guard var url = components.url, let path = setPathParams(request.requestEndPoint) else { return nil }

--- a/Sources/FormbricksSDK/Networking/Base/APIClient.swift
+++ b/Sources/FormbricksSDK/Networking/Base/APIClient.swift
@@ -14,7 +14,7 @@ class APIClient<Request: CodableRequest>: Operation, @unchecked Sendable {
     
     override func main() {
         guard let finalURL = buildFinalURL() else {
-            completion?(.failure(FormbricksSDKError(type: .sdkIsNotInitialized)))
+            completion?(.failure(FormbricksSDKError(type: .invalidAppUrl)))
             return
         }
         
@@ -33,10 +33,9 @@ class APIClient<Request: CodableRequest>: Operation, @unchecked Sendable {
         guard let scheme = components.scheme?.lowercased(), scheme == "https" else {
             let errorMessage = "HTTP requests are blocked for security. Only HTTPS requests are allowed. Provided app url: \(apiURL)"
             Formbricks.logger?.error(errorMessage)
-            completion?(.failure(FormbricksSDKError(type: .invalidAppUrl)))
             return nil
         }
-        
+
         components.queryItems = request.queryParams?.map { URLQueryItem(name: $0.key, value: $0.value) }
         
         guard var url = components.url, let path = setPathParams(request.requestEndPoint) else { return nil }
@@ -93,7 +92,7 @@ class APIClient<Request: CodableRequest>: Operation, @unchecked Sendable {
     
     private func handleFailureResponse(data: Data?, error: Error?, statusCode: Int, message: String) {
         var log = message
-
+        
         if let error = error {
             log.append("\nError: \(error.localizedDescription)")
             Formbricks.logger?.error(log)

--- a/Tests/FormbricksSDKTests/FormbricksSDKTests.swift
+++ b/Tests/FormbricksSDKTests/FormbricksSDKTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class FormbricksSDKTests: XCTestCase {
     let environmentId = "environmentId"
-    let appUrl = "appUrl"
+    let appUrl = "https://example.com"
     let userId = "6CCCE716-6783-4D0F-8344-9C7DFA43D8F7"
     let surveyID = "cm6ovw6j7000gsf0kduf4oo4i"
     let mockService = MockFormbricksService()

--- a/Tests/FormbricksSDKTests/Networking/APIClientTests.swift
+++ b/Tests/FormbricksSDKTests/Networking/APIClientTests.swift
@@ -28,10 +28,22 @@ final class APIClientTests: XCTestCase {
         let name: String
     }
     
-    private struct MockEnvironmentResponse: Codable {
-        var responseString: String?
-        let id: String
-        let name: String
+    private struct MockVoidRequest: CodableRequest {
+        typealias Response = VoidResponse
+        
+        var baseURL: String?
+        var requestEndPoint: String
+        var requestType: HTTPMethod
+        var headers: [String: String]?
+        var queryParams: [String: String]?
+        var pathParams: [String: String]?
+        var requestBody: Data?
+        
+        var decoder: JSONDecoder {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return decoder
+        }
     }
     
     // MARK: - Properties
@@ -106,7 +118,10 @@ final class APIClientTests: XCTestCase {
         let request = MockRequest(
             baseURL: "https://api.test.com",
             requestEndPoint: "/test",
-            requestType: .get
+            requestType: .get,
+            headers: [
+                "some": "some"
+            ]
         )
         
         mockURLSession.mockData = errorData
@@ -153,7 +168,7 @@ final class APIClientTests: XCTestCase {
             case .success:
                 XCTFail("Expected failure but got success")
             case .failure(let error as FormbricksSDKError):
-                XCTAssertEqual(error.type, .sdkIsNotInitialized)
+                XCTAssertEqual(error.type, .invalidAppUrl)
             case .failure(let error):
                 XCTFail("Expected FormbricksSDKError but got: \(type(of: error))")
             }
@@ -204,13 +219,18 @@ final class APIClientTests: XCTestCase {
     func testVoidResponse() {
         // Given
         let expectation = XCTestExpectation(description: "API call completes")
-        let request = MockRequest(
+        
+        // Create a request that expects a VoidResponse
+        var request = MockVoidRequest(
             baseURL: "https://api.test.com",
             requestEndPoint: "/test",
             requestType: .get
         )
+        request.pathParams = [
+            "{someId}": "someValue",
+        ]
         
-        mockURLSession.mockData = "{}".data(using: .utf8)
+        mockURLSession.mockData = Data() // Empty data for a void response
         mockURLSession.mockResponse = HTTPURLResponse(
             url: URL(string: "https://api.test.com")!,
             statusCode: 200,
@@ -219,63 +239,19 @@ final class APIClientTests: XCTestCase {
         )
         
         // When
-        sut = APIClient(request: request, session: mockURLSession) { result in
+        let apiClient = APIClient(request: request, session: mockURLSession) { result in
             // Then
             switch result {
-            case .success:
-                XCTAssertTrue(true)
+            case .success(let response):
+                // Ensure the response is of type VoidResponse
+                XCTAssertTrue(response is VoidResponse)
             case .failure(let error):
-                let normalized = error.localizedDescription
-                    .replacingOccurrences(of: "’", with: "'") // curly to straight apostrophe
-                    .replacingOccurrences(of: "‘", with: "'") // opening curly to straight
-                    .lowercased() // optional: ignore case
-
-                XCTAssertTrue(normalized.contains("couldn't be completed"))
+                XCTFail("Expected success but got error: \(error)")
             }
             expectation.fulfill()
         }
         
-        sut.main()
-        wait(for: [expectation], timeout: 1.0)
-    }
-    
-    func testNetworkError() {
-        // Given
-        let expectation = XCTestExpectation(description: "API call completes")
-        let networkError = NSError(domain: "test", code: -1009, userInfo: [NSLocalizedDescriptionKey: "No internet connection"])
-        
-        let request = MockRequest(
-            baseURL: "https://api.test.com",
-            requestEndPoint: "/test",
-            requestType: .get
-        )
-        
-        mockURLSession.mockError = networkError
-        mockURLSession.mockResponse = HTTPURLResponse(
-            url: URL(string: "https://api.test.com")!,
-            statusCode: 0,
-            httpVersion: nil,
-            headerFields: nil
-        )
-        
-        // When
-        sut = APIClient(request: request, session: mockURLSession) { result in
-            // Then
-            switch result {
-            case .success:
-                XCTFail("Expected failure but got success")
-            case .failure(let error):
-                let normalized = error.localizedDescription
-                    .replacingOccurrences(of: "’", with: "'") // curly to straight apostrophe
-                    .replacingOccurrences(of: "‘", with: "'") // opening curly to straight
-                    .lowercased() // optional: ignore case
-
-                XCTAssertTrue(normalized.contains("couldn't be completed"))
-            }
-            expectation.fulfill()
-        }
-        
-        sut.main()
+        apiClient.main()
         wait(for: [expectation], timeout: 1.0)
     }
     
@@ -352,6 +328,351 @@ final class APIClientTests: XCTestCase {
         }
         
         sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testHttpSchemeBlocked() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes with invalid app URL error")
+        var request = MockRequest(
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        request.baseURL = "http://api.test.com"
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .failure(let error as FormbricksSDKError):
+                XCTAssertEqual(error.type, .invalidAppUrl)
+            default:
+                XCTFail("Expected FormbricksSDKError with type invalidAppUrl, but got something else.")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testDataIsNil() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes with invalid response error")
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        mockURLSession.mockData = nil // Data is nil
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .failure(let error as FormbricksAPIClientError):
+                XCTAssertEqual(error.type, .invalidResponse)
+            default:
+                XCTFail("Expected FormbricksAPIClientError with type invalidResponse, but got something else.")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testInvalidResponse() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes with invalid response error")
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        mockURLSession.mockResponse = nil // Response is not an HTTPURLResponse
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .failure(let error as FormbricksAPIClientError):
+                XCTAssertEqual(error.type, .invalidResponse)
+            default:
+                XCTFail("Expected FormbricksAPIClientError with type invalidResponse, but got something else.")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testResponseErrorWithoutData() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes with response error")
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        mockURLSession.mockData = nil // Data is nil
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .failure(let error as FormbricksAPIClientError):
+                XCTAssertEqual(error.type, .responseError)
+            default:
+                XCTFail("Expected FormbricksAPIClientError with type responseError, but got something else.")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testDecodingDataCorrupted() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes with decoding error")
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        let corruptedData = "corrupted data".data(using: .utf8)
+        mockURLSession.mockData = corruptedData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .failure(let error as FormbricksAPIClientError):
+                XCTAssertEqual(error.type, .invalidResponse)
+            default:
+                XCTFail("Expected FormbricksAPIClientError with type invalidResponse, but got something else.")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testDecodingKeyNotFound() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes with decoding error")
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        // JSON missing the 'name' key
+        let incompleteData = "{\"id\": \"123\"}".data(using: .utf8)
+        mockURLSession.mockData = incompleteData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .failure(let error as FormbricksAPIClientError):
+                XCTAssertEqual(error.type, .invalidResponse)
+            default:
+                XCTFail("Expected FormbricksAPIClientError with type invalidResponse, but got something else.")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testDecodingValueNotFound() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes with decoding error")
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        // 'name' key has a null value, which is not expected
+        let nullValueData = "{\"id\": \"123\", \"name\": null}".data(using: .utf8)
+        mockURLSession.mockData = nullValueData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .failure(let error as FormbricksAPIClientError):
+                XCTAssertEqual(error.type, .invalidResponse)
+            default:
+                XCTFail("Expected FormbricksAPIClientError with type invalidResponse, but got something else.")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testDecodingTypeMismatch() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes with decoding error")
+        let request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test",
+            requestType: .get
+        )
+        
+        // 'id' is a number instead of a string
+        let typeMismatchData = "{\"id\": 123, \"name\": \"Test\"}".data(using: .utf8)
+        mockURLSession.mockData = typeMismatchData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .failure(let error as FormbricksAPIClientError):
+                XCTAssertEqual(error.type, .invalidResponse)
+            default:
+                XCTFail("Expected FormbricksAPIClientError with type invalidResponse, but got something else.")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testSuccessfulResponseWithBody() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes")
+        let mockResponse = MockResponse(id: "123", name: "Test")
+        let responseData = try! JSONEncoder().encode(mockResponse)
+        
+        var request = MockRequest(
+            baseURL: "https://api.test.com",
+            requestEndPoint: "/test/{environmentId}",
+            requestType: .get
+        )
+        
+        request.requestBody = "test".data(using: .utf8)
+        
+        mockURLSession.mockData = responseData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        sut = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.id, "123")
+                XCTAssertEqual(response.name, "Test")
+            case .failure(let error):
+                XCTFail("Expected success but got error: \(error)")
+            }
+            expectation.fulfill()
+        }
+        
+        sut.main()
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testEnvironmentResponse() {
+        // Given
+        let expectation = XCTestExpectation(description: "API call completes")
+        
+        let request = GetEnvironmentRequest()
+        Formbricks.appUrl = "https://api.test.com"
+        addTeardownBlock {
+            Formbricks.appUrl = nil
+        }
+        
+        let mockJSON = """
+        {
+            "data": {
+                "data": {
+                    "project": {}
+                },
+                "expiresAt": "2099-12-31T23:59:59.999Z"
+            }
+        }
+        """
+        
+        let mockData = mockJSON.data(using: .utf8)!
+        
+        mockURLSession.mockData = mockData
+        mockURLSession.mockResponse = HTTPURLResponse(
+            url: URL(string: "https://api.test.com")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        
+        // When
+        let apiClient = APIClient(request: request, session: mockURLSession) { result in
+            // Then
+            switch result {
+            case .success(let response):
+                // Additional check to see if the responseString is populated
+                XCTAssertNotNil(response.responseString)
+                XCTAssertTrue(response.responseString!.contains("2099-12-31T23:59:59.999Z"))
+            case .failure(let error):
+                XCTFail("Expected success, but got an error: \(error.localizedDescription)")
+            }
+            expectation.fulfill()
+        }
+        
+        apiClient.main()
         wait(for: [expectation], timeout: 1.0)
     }
 }


### PR DESCRIPTION
This pull request introduces security enhancements and code cleanup in the `FormbricksSDK` module. The most significant changes include enforcing HTTPS for all URLs, improving error handling during SDK setup, and removing unused code for better maintainability.

### Security Enhancements:
* [`Sources/FormbricksSDK/Formbricks.swift`](diffhunk://#diff-937c1ccfca3918da12966d6f9203b9f02077b231d5a36456b7fe8d4e6bfabb26L59-R72): Added validation to ensure `appUrl` uses HTTPS and block HTTP requests for security. Improved error handling with descriptive messages when `appUrl` is invalid.
* [`Sources/FormbricksSDK/Networking/Base/APIClient.swift`](diffhunk://#diff-9d7f3602e3bc79409802e96ceee79c0cf311f24e35445874ea229a4b41bdab2eR32-R39): Modified the `buildFinalURL` method to enforce HTTPS for requests, logging errors and aborting operations if HTTP is detected.

### Code Cleanup:
* [`Sources/FormbricksSDK/Manager/SurveyManager.swift`](diffhunk://#diff-f15df4851352e3c8871c2f41be5825227bdc59c5fc26f78c808bda6fd803bb33L29-L30): Removed unused `service` property and cleaned up redundant whitespace in the `SurveyManager` class and its extension. [[1]](diffhunk://#diff-f15df4851352e3c8871c2f41be5825227bdc59c5fc26f78c808bda6fd803bb33L29-L30) [[2]](diffhunk://#diff-f15df4851352e3c8871c2f41be5825227bdc59c5fc26f78c808bda6fd803bb33L314)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to ensure only HTTPS URLs are accepted during SDK initialization and networking operations, enhancing security and preventing setup with invalid or insecure URLs.
- **Tests**
  - Expanded test coverage with new cases for error handling, URL scheme enforcement, and response validation.
  - Refined existing tests to verify success scenarios and correct response parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->