### PR TITLE
fix: branding text

### DIFF
--- a/Sources/FormbricksSDK/WebView/FormbricksViewModel.swift
+++ b/Sources/FormbricksSDK/WebView/FormbricksViewModel.swift
@@ -98,6 +98,7 @@ private class WebViewData {
         data["environmentId"] = Formbricks.environmentId
         data["contactId"] = Formbricks.userManager?.contactId
         data["isWebEnvironment"] = false
+        data["isBrandingEnabled"] = environmentResponse.data.data.project.inAppSurveyBranding ?? true
         
         let isMultiLangSurvey = environmentResponse.data.data.surveys?.first(where: { $0.id == surveyId })?.languages?.count ?? 0 > 1
         

--- a/Sources/FormbricksSDK/WebView/FormbricksViewModel.swift
+++ b/Sources/FormbricksSDK/WebView/FormbricksViewModel.swift
@@ -93,7 +93,6 @@ private class WebViewData {
     
     init(environmentResponse: EnvironmentResponse, surveyId: String) {
         data["survey"] = environmentResponse.getSurveyJson(forSurveyId: surveyId)
-        data["isBrandingEnabled"] = true
         data["appUrl"] = Formbricks.appUrl
         data["environmentId"] = Formbricks.environmentId
         data["contactId"] = Formbricks.userManager?.contactId


### PR DESCRIPTION
Fixes https://github.com/formbricks/internal/issues/651
This pull request introduces a minor enhancement to the `WebViewData` class in `FormbricksViewModel.swift`. The change adds a new key-value pair to the `data` dictionary to support branding configuration for in-app surveys.

Enhancement to branding configuration:

* Added `isBrandingEnabled` to the `data` dictionary, which determines whether in-app survey branding is enabled based on the `environmentResponse` data. Defaults to `true` if the value is not provided. (`Sources/FormbricksSDK/WebView/FormbricksViewModel.swift`, [Sources/FormbricksSDK/WebView/FormbricksViewModel.swiftR101](diffhunk://#diff-85f7d1f20685cf85aba9ce87b1fcaf2af18dbf7b0c483c4d99ecfb0deaaa1cd3R101))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
  - The branding display setting now accurately reflects the project configuration, ensuring branding is shown or hidden based on your project’s preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->