### PR TITLE
fix: targeted surveys will not be shown to anonymous users

### DIFF
--- a/Sources/FormbricksSDK/Manager/SurveyManager.swift
+++ b/Sources/FormbricksSDK/Manager/SurveyManager.swift
@@ -46,6 +46,19 @@ final class SurveyManager {
         
         filteredSurveys = filterSurveysBasedOnDisplayType(surveys, displays: displays, responses: responses)
         filteredSurveys = filterSurveysBasedOnRecontactDays(filteredSurveys, defaultRecontactDays: environment.data.data.project.recontactDays)
+        
+        // If we don't have a user, we exclude surveys that have segments with filters
+        if userManager.userId == nil {
+            filteredSurveys = filteredSurveys.filter { survey in
+                // Include surveys with no segment
+                guard let segment = survey.segment else {
+                    return true
+                }
+                
+                // Include surveys with segments but no filters
+                return segment.filters.isEmpty
+            }
+        }
                 
         // If we have a user, we do more filtering
         if userManager.userId != nil {

--- a/Sources/FormbricksSDK/Manager/UserManager.swift
+++ b/Sources/FormbricksSDK/Manager/UserManager.swift
@@ -139,6 +139,9 @@ final class UserManager: UserManagerSyncable {
         syncTimer = nil
         updateQueue?.cleanup()
         
+        // Re-filter surveys for logged out user
+        surveyManager?.filterSurveys()
+        
         if isUserIdDefined {
             Formbricks.logger?.debug("Successfully logged out user and reset the user state.")
         }


### PR DESCRIPTION
Fixes #27 
Targeted surveys (surveys having segment filters) will not be shown to unidentified (anonymous) users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved survey filtering to ensure only relevant surveys are shown when no user is logged in.
  * Surveys are now re-filtered immediately after logout to reflect the updated user state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->