### PR TITLE
fix: fixes safe area bug

### DIFF
--- a/Sources/FormbricksSDK/WebView/FormbricksView.swift
+++ b/Sources/FormbricksSDK/WebView/FormbricksView.swift
@@ -7,6 +7,7 @@ struct FormbricksView: View {
     var body: some View {
         if let htmlString = viewModel.htmlString {
             SurveyWebView(surveyId: viewModel.surveyId, htmlString: htmlString)
+                .ignoresSafeArea()
         }
     }
 }

--- a/Sources/FormbricksSDK/WebView/SurveyWebView.swift
+++ b/Sources/FormbricksSDK/WebView/SurveyWebView.swift
@@ -31,6 +31,7 @@ struct SurveyWebView: UIViewRepresentable {
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
         webView.scrollView.isScrollEnabled = false
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
         return webView
     }
     


### PR DESCRIPTION
Fixes a bug with the ios sdk where the safe area was not ignored
Before:
<img width="390" height="843" alt="Screenshot 2026-02-17 at 12 45 00" src="https://github.com/user-attachments/assets/85e34942-1d0a-43db-be5f-58daedc9dd10" />

After:
<img width="447" height="973" alt="Screenshot 2026-02-17 at 12 45 12" src="https://github.com/user-attachments/assets/97a7facf-6ce0-46d3-ab1a-5de116e9ded8" />
